### PR TITLE
sveltejs/template is no longer maintained by sveltejs team

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Simple Combination of FastAPI and Svelte.
 
 1. Clone this Repo ```git clone https://github.com/Gingerbreadfork/fastapi-svelte```
 3. ```pip install -r requirements.txt``` to install python dependencies (ideally in a virtualenv or similar - don't be a savage).
-4. Run ```npx degit sveltejs/template client``` inside root directory to create Svelte app inside ```client``` directory.
+4. Run ```npm create vite@latest client -- --template svelte``` inside root directory to create Svelte app inside ```client``` directory.
 5. Inside ```client``` directory run ```npm install```
 
 ## Local Development:

--- a/main.py
+++ b/main.py
@@ -5,4 +5,4 @@ from fastapi.staticfiles import StaticFiles
 app = FastAPI()
 
 # Place After All Other Routes
-app.mount('', StaticFiles(directory="client/public/", html=True), name="static")
+app.mount('', StaticFiles(directory="client/dist/", html=True), name="static")


### PR DESCRIPTION
sveltejs/template repo is archived and will be no longer update, Svelte team recommend to use vite as a scaffolding tools for svelte.